### PR TITLE
Move logs to logger

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -1026,7 +1026,7 @@ class AstVisitor(SolidityVisitor):
         return ctx.getText()
 
 
-def parse(text, start="sourceUnit", loc=False, strict=False):
+def parse(text, start="sourceUnit", loc=False, strict=False, logger=None):
     from antlr4.InputStream import InputStream
     from antlr4 import FileStream, CommonTokenStream
 
@@ -1034,7 +1034,7 @@ def parse(text, start="sourceUnit", loc=False, strict=False):
 
     lexer = SolidityLexer(input_stream)
     token_stream = CommonTokenStream(lexer)
-    parser = SolidityParser(token_stream)
+    parser = SolidityParser(token_stream, logger=logger)
     ast = AstVisitor()
 
     Node.ENABLE_LOC = loc


### PR DESCRIPTION
The parsers in the solidy parser repo are using antlr to log errors. The way antlr does it is by creating a listener class that will print the log and register the parser with a default listener that print to console. Since antlr is a external library (that we don't want to create a local repo for), I inherited from a listener and registered it to the parsers (and also deregistered all other listeners). The new listener just log all messages as debug logs.

Since the actual ErrorListener object I wanted to inherit from is not accessible from outside antlr I had to inherit from a child of the ErrorListener that implemets some of the ErrorListener other functions. To avoid a lot of extra logs that the "Middle" class what printing I overridden the functions with pass 🤮 (If only I could use the parent ErrorListener)